### PR TITLE
Update project tt_um_cw_vref (christoph-weiser/tt10-vref)

### DIFF
--- a/projects/tt_um_cw_vref/commit_id.json
+++ b/projects/tt_um_cw_vref/commit_id.json
@@ -1,8 +1,8 @@
 {
   "app": "custom_gds action",
   "repo": "https://github.com/christoph-weiser/tt10-vref",
-  "commit": "fe47cf75f35f1db71475cda8941946c5753c8dc6",
-  "workflow_url": "https://github.com/christoph-weiser/tt10-vref/actions/runs/16079759653",
+  "commit": "581afd97c5affc0a02d50c5fe338584d04e37f9c",
+  "workflow_url": "https://github.com/christoph-weiser/tt10-vref/actions/runs/17412508527",
   "sort_id": 1751657090337,
   "analog": true
 }


### PR DESCRIPTION
Update project tt_um_cw_vref to commit christoph-weiser/tt10-vref@581afd97c5affc0a02d50c5fe338584d04e37f9c

Project title: Current-Mode Bandgap Reference
Tiles: 2x2
Workflow: https://github.com/christoph-weiser/tt10-vref/actions/runs/17412508527
Project submission: https://app.tinytapeout.com/projects/2643

